### PR TITLE
Fix XML charset decoding issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val root = tlCrossRootProject.aggregate(scalaXml)
 
 val http4sVersion = "0.23.12"
 val scalaXmlVersion = "2.1.0"
-val fs2DataVersion = "1.4.0"
+val fs2DataVersion = "1.5.0"
 val munitVersion = "0.7.29"
 val munitCatsEffectVersion = "1.0.7"
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,12 @@ val Scala213 = "2.13.8"
 ThisBuild / crossScalaVersions := Seq("2.12.16", Scala213, "3.1.2")
 ThisBuild / scalaVersion := Scala213
 
+// ensure missing timezones don't break tests on JS
+ThisBuild / jsEnv := {
+  import org.scalajs.jsenv.nodejs.NodeJSEnv
+  new NodeJSEnv(NodeJSEnv.Config().withEnv(Map("TZ" -> "UTC")))
+}
+
 lazy val root = tlCrossRootProject.aggregate(scalaXml)
 
 val http4sVersion = "0.23.12"

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ class JsonXmlHttpEndpoint[F[_]](implicit F: Async[F]) extends Http4sDsl[F] {
   }
 
   private def personXmlDecoder: EntityDecoder[F, Person] =
-    org.http4s.scalaxml.xmlDecoder[F].map(Person.fromXml)
+    org.http4s.scalaxml.xmlDocument[F].map(Person.fromXml)
 
   implicit private def jsonXmlDecoder: EntityDecoder[F, Person] =
     jsonOf[F, Person].orElse(personXmlDecoder)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,4 @@
 addSbtPlugin("org.http4s" % "sbt-http4s-org" % "0.14.3")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.0")
+// Fix links to API docs of scala-xml
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")

--- a/scala-xml/src/main/scala/org/http4s/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/org/http4s/scalaxml/ElemInstances.scala
@@ -126,8 +126,8 @@ trait ElemInstances {
   // and additional whitespace is not allowed, so this strict regex should work reliably.
   private val prologWithEncoding: Regex = """<\?xml version=".+" encoding="([^"]+)".*""".r
 
-  private val `BOM-BE` = Chunk(0xfe.toByte, 0xff.toByte)
-  private val `BOM-LE` = Chunk(0xff.toByte, 0xfe.toByte)
+  private lazy val `BOM-BE` = Chunk(0xfe.toByte, 0xff.toByte)
+  private lazy val `BOM-LE` = Chunk(0xff.toByte, 0xfe.toByte)
 
   private def guessCharset(in: String): ParseResult[Charset] = in match {
     case prologWithEncoding(encoding) => Charset.fromString(encoding)

--- a/scala-xml/src/main/scala/org/http4s/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/org/http4s/scalaxml/ElemInstances.scala
@@ -19,7 +19,9 @@ package scalaxml
 
 import cats.effect.Concurrent
 import cats.syntax.all._
-import fs2.{Chunk, Pull, Stream}
+import fs2.Chunk
+import fs2.Pull
+import fs2.Stream
 import fs2.data.xml.XmlEvent
 import fs2.data.xml.XmlException
 import fs2.data.xml.scalaXml._

--- a/scala-xml/src/main/scala/org/http4s/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/org/http4s/scalaxml/ElemInstances.scala
@@ -19,14 +19,16 @@ package scalaxml
 
 import cats.effect.Concurrent
 import cats.syntax.all._
-import fs2.Stream
+import fs2.{Chunk, Pull, Stream}
 import fs2.data.xml.XmlEvent
 import fs2.data.xml.XmlException
 import fs2.data.xml.scalaXml._
+import fs2.text.decodeWithCharset
 import org.http4s.Charset.`UTF-8`
 import org.http4s.headers.`Content-Type`
 
 import java.io.StringWriter
+import scala.util.matching.Regex
 import scala.xml.Document
 import scala.xml.Elem
 import scala.xml.XML
@@ -51,7 +53,42 @@ trait ElemInstances {
   )(implicit F: Concurrent[F]): EntityDecoder[F, Stream[F, XmlEvent]] =
     EntityDecoder.decodeBy(MediaType.text.xml, MediaType.text.html, MediaType.application.xml) {
       msg =>
-        DecodeResult.successT(msg.bodyText.through(fs2.data.xml.events(includeComments)))
+        DecodeResult.successT(
+          msg.body.pull
+            .unconsN(64, allowFewer = true)
+            // look at the first bytes to check for BOM or encoding spec in the prolog
+            .flatMap {
+              case Some((chunk, tail)) if chunk.take(2) === `BOM-BE` =>
+                tail
+                  .cons(chunk.drop(2)) // drop BOM
+                  .through(decodeWithCharset(Charset.`UTF-16BE`.nioCharset))
+                  .pull
+                  .echo
+              case Some((chunk, tail)) if chunk.take(2) === `BOM-LE` =>
+                tail
+                  .cons(chunk.drop(2)) // drop BOM
+                  .through(decodeWithCharset(Charset.`UTF-16LE`.nioCharset))
+                  .pull
+                  .echo
+              case Some((chunk, tail)) if msg.charset.isEmpty =>
+                // guard: xml prolog is only authoritative if content type is missing, see RFC 7303 §8.8
+                guessCharset(new String(chunk.toArray, `UTF-8`.nioCharset))
+                  .fold(
+                    Pull.raiseError[F](_),
+                    charset =>
+                      tail.cons(chunk).through(decodeWithCharset(charset.nioCharset)).pull.echo,
+                  )
+              case Some((chunk, tail)) =>
+                tail
+                  .cons(chunk)
+                  .through(decodeWithCharset(msg.charset.getOrElse(`UTF-8`).nioCharset))
+                  .pull
+                  .echo
+              case None => Pull.done
+            }
+            .stream
+            .through(fs2.data.xml.events(includeComments))
+        )
     }
 
   /** Handles a message body as XML.
@@ -82,4 +119,16 @@ trait ElemInstances {
           .widen
       }
     }
+
+  // Extract the encoding from the XML prolog if present. Attribute order is fixed for prologs by the spec
+  // and additional whitespace is not allowed, so this strict regex should work reliably.
+  private val prologWithEncoding: Regex = """<\?xml version=".+" encoding="([^"]+)".*""".r
+
+  private val `BOM-BE` = Chunk(0xfe.toByte, 0xff.toByte)
+  private val `BOM-LE` = Chunk(0xff.toByte, 0xfe.toByte)
+
+  private def guessCharset(in: String): ParseResult[Charset] = in match {
+    case prologWithEncoding(encoding) => Charset.fromString(encoding)
+    case _ => Right(Charset.`UTF-8`)
+  }
 }

--- a/scala-xml/src/main/scala/org/http4s/scalaxml/ElemInstances.scala
+++ b/scala-xml/src/main/scala/org/http4s/scalaxml/ElemInstances.scala
@@ -93,14 +93,14 @@ trait ElemInstances {
 
   /** Handles a message body as XML.
     *
-    * @return an XML [[Document]]
+    * @return an XML [[scala.xml.Document]]
     */
   implicit def xmlDocument[F[_]: Concurrent]: EntityDecoder[F, Document] =
     xmlDocument(true)
 
   /** Handles a message body as XML.
     *
-    * @return an XML [[Document]]
+    * @return an XML [[scala.xml.Document]]
     */
   def xmlDocument[F[_]](
       includeComments: Boolean

--- a/scala-xml/src/test/scala/org/http4s/scalaxml/ScalaXmlSuite.scala
+++ b/scala-xml/src/test/scala/org/http4s/scalaxml/ScalaXmlSuite.scala
@@ -260,7 +260,9 @@ class ScalaXmlSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
       ),
       "application/xml; charset=iso-2022-kr",
       "문재인",
-    )
+    ).unlessA(
+      sys.props("java.vm.name") === "Scala.js"
+    ) // exclude test on Scala.js as it doesn't support this charset
   }
 
   test("parse conflicting charset and internal encoding") {

--- a/scala-xml/src/test/scala/org/http4s/scalaxml/ScalaXmlSuite.scala
+++ b/scala-xml/src/test/scala/org/http4s/scalaxml/ScalaXmlSuite.scala
@@ -228,6 +228,32 @@ class ScalaXmlSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
     )
   }
 
+  test("parse omitted charset and 16-Bit MIME Entity (big endian)") {
+    // https://datatracker.ietf.org/doc/html/rfc7303#section-8.4 (second example)
+    encodingTest(
+      Chunk(0xfe.toByte, 0xff.toByte) ++ Chunk.array(
+        """<?xml version="1.0" encoding="utf-16"?><hello name="Günther"/>""".getBytes(
+          StandardCharsets.UTF_16BE
+        )
+      ),
+      "application/xml",
+      "Günther",
+    )
+  }
+
+  test("parse omitted charset and 16-Bit MIME Entity (little endian)") {
+    // https://datatracker.ietf.org/doc/html/rfc7303#section-8.4 (second example)
+    encodingTest(
+      Chunk(0xff.toByte, 0xfe.toByte) ++ Chunk.array(
+        """<?xml version="1.0" encoding="utf-16"?><hello name="Günther"/>""".getBytes(
+          StandardCharsets.UTF_16LE
+        )
+      ),
+      "application/xml",
+      "Günther",
+    )
+  }
+
   test("parse omitted charset, no internal encoding declaration") {
     // https://datatracker.ietf.org/doc/html/rfc7303#section-8.5
     encodingTest(

--- a/scala-xml/src/test/scala/org/http4s/scalaxml/ScalaXmlSuite.scala
+++ b/scala-xml/src/test/scala/org/http4s/scalaxml/ScalaXmlSuite.scala
@@ -258,7 +258,7 @@ class ScalaXmlSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
           "iso-2022-kr"
         )
       ),
-      "application/xml; charset=iso-2022kr",
+      "application/xml; charset=iso-2022-kr",
       "문재인",
     )
   }


### PR DESCRIPTION
Note that this PR goes against @rossabaker's #3 to highlight what was changed on top.

It updates the fs2-data version to incorporate relevant bug fixes and implements a stream-peek solution for charset detection that passes all the tests based on RFC 7303 (BOM & encoding spec in the XML prolog).

Locally I've seen two test failures on JS due to missing timezone (coming from http4s' `Arbitrary` collection) and charset support, it lacks `iOS-2022-kr`. Let's see what CI says.

Special thanks to @armanbilge for triggering my interest in this project again on Discord.