### PR TITLE
Split xml modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,21 +29,25 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.16, 2.13.8, 3.1.3]
+        scala: [2.12.17, 2.13.9, 3.2.0]
         java: [temurin@8, temurin@11, temurin@17]
-        project: [rootJS, rootJVM]
+        project: [rootJS, rootJVM, rootNative]
         exclude:
-          - scala: 2.12.16
+          - scala: 2.12.17
             java: temurin@11
-          - scala: 2.12.16
+          - scala: 2.12.17
             java: temurin@17
-          - scala: 3.1.3
+          - scala: 3.2.0
             java: temurin@11
-          - scala: 3.1.3
+          - scala: 3.2.0
             java: temurin@17
           - project: rootJS
             java: temurin@11
           - project: rootJS
+            java: temurin@17
+          - project: rootNative
+            java: temurin@11
+          - project: rootNative
             java: temurin@17
     runs-on: ${{ matrix.os }}
     steps:
@@ -123,6 +127,10 @@ jobs:
         if: matrix.project == 'rootJS'
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' Test/scalaJSLinkerResult
 
+      - name: nativeLink
+        if: matrix.project == 'rootNative'
+        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' Test/nativeLink
+
       - name: Test
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' test
 
@@ -144,11 +152,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p target .js/target site/target .jvm/target .native/target scala-xml/.js/target scala-xml/.jvm/target project/target
+        run: mkdir -p target .js/target site/target xml/.jvm/target xml-scala/.js/target xml/.js/target xml-scala/.native/target xml-scala/.jvm/target .jvm/target .native/target xml/.native/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar target .js/target site/target .jvm/target .native/target scala-xml/.js/target scala-xml/.jvm/target project/target
+        run: tar cf targets.tar target .js/target site/target xml/.jvm/target xml-scala/.js/target xml/.js/target xml-scala/.native/target xml-scala/.jvm/target .jvm/target .native/target xml/.native/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
@@ -164,7 +172,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.8]
+        scala: [2.13.9]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -233,62 +241,92 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Download target directories (2.12.16, rootJS)
+      - name: Download target directories (2.12.17, rootJS)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.16-rootJS
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.17-rootJS
 
-      - name: Inflate target directories (2.12.16, rootJS)
+      - name: Inflate target directories (2.12.17, rootJS)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.12.16, rootJVM)
+      - name: Download target directories (2.12.17, rootJVM)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.16-rootJVM
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.17-rootJVM
 
-      - name: Inflate target directories (2.12.16, rootJVM)
+      - name: Inflate target directories (2.12.17, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.13.8, rootJS)
+      - name: Download target directories (2.12.17, rootNative)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.8-rootJS
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.17-rootNative
 
-      - name: Inflate target directories (2.13.8, rootJS)
+      - name: Inflate target directories (2.12.17, rootNative)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.13.8, rootJVM)
+      - name: Download target directories (2.13.9, rootJS)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.8-rootJVM
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.9-rootJS
 
-      - name: Inflate target directories (2.13.8, rootJVM)
+      - name: Inflate target directories (2.13.9, rootJS)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.1.3, rootJS)
+      - name: Download target directories (2.13.9, rootJVM)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.3-rootJS
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.9-rootJVM
 
-      - name: Inflate target directories (3.1.3, rootJS)
+      - name: Inflate target directories (2.13.9, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.1.3, rootJVM)
+      - name: Download target directories (2.13.9, rootNative)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3.1.3-rootJVM
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.9-rootNative
 
-      - name: Inflate target directories (3.1.3, rootJVM)
+      - name: Inflate target directories (2.13.9, rootNative)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.2.0, rootJS)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.0-rootJS
+
+      - name: Inflate target directories (3.2.0, rootJS)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.2.0, rootJVM)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.0-rootJVM
+
+      - name: Inflate target directories (3.2.0, rootJVM)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.2.0, rootNative)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.0-rootNative
+
+      - name: Inflate target directories (3.2.0, rootNative)
         run: |
           tar xf targets.tar
           rm targets.tar
@@ -312,7 +350,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.8]
+        scala: [2.13.9]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         os: [ubuntu-latest]
         scala: [2.12.17, 2.13.10, 3.2.0]
         java: [temurin@8, temurin@11, temurin@17]
-        project: [rootJS, rootJVM]
+        project: [rootJS, rootJVM, rootNative]
         exclude:
           - scala: 2.12.17
             java: temurin@11
@@ -44,6 +44,10 @@ jobs:
           - project: rootJS
             java: temurin@11
           - project: rootJS
+            java: temurin@17
+          - project: rootNative
+            java: temurin@11
+          - project: rootNative
             java: temurin@17
     runs-on: ${{ matrix.os }}
     steps:
@@ -123,6 +127,10 @@ jobs:
         if: matrix.project == 'rootJS'
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' Test/scalaJSLinkerResult
 
+      - name: nativeLink
+        if: matrix.project == 'rootNative'
+        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' Test/nativeLink
+
       - name: Test
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' test
 
@@ -144,11 +152,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p target .js/target site/target .jvm/target .native/target scala-xml/.js/target scala-xml/.jvm/target project/target
+        run: mkdir -p target .js/target site/target xml/.jvm/target xml-scala/.js/target xml/.js/target xml-scala/.native/target xml-scala/.jvm/target .jvm/target .native/target xml/.native/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar target .js/target site/target .jvm/target .native/target scala-xml/.js/target scala-xml/.jvm/target project/target
+        run: tar cf targets.tar target .js/target site/target xml/.jvm/target xml-scala/.js/target xml/.js/target xml-scala/.native/target xml-scala/.jvm/target .jvm/target .native/target xml/.native/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
@@ -253,6 +261,16 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
+      - name: Download target directories (2.12.17, rootNative)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.17-rootNative
+
+      - name: Inflate target directories (2.12.17, rootNative)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
       - name: Download target directories (2.13.10, rootJS)
         uses: actions/download-artifact@v2
         with:
@@ -273,6 +291,16 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
+      - name: Download target directories (2.13.10, rootNative)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.10-rootNative
+
+      - name: Inflate target directories (2.13.10, rootNative)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
       - name: Download target directories (3.2.0, rootJS)
         uses: actions/download-artifact@v2
         with:
@@ -289,6 +317,16 @@ jobs:
           name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.0-rootJVM
 
       - name: Inflate target directories (3.2.0, rootJVM)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.2.0, rootNative)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.0-rootNative
+
+      - name: Inflate target directories (3.2.0, rootNative)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        scala: [2.12.17, 2.13.9, 3.2.0]
+        scala: [2.12.17, 2.13.10, 3.2.0]
         java: [temurin@8, temurin@11, temurin@17]
         project: [rootJS, rootJVM, rootNative]
         exclude:
@@ -172,7 +172,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.9]
+        scala: [2.13.10]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -271,32 +271,32 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.13.9, rootJS)
+      - name: Download target directories (2.13.10, rootJS)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.9-rootJS
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.10-rootJS
 
-      - name: Inflate target directories (2.13.9, rootJS)
+      - name: Inflate target directories (2.13.10, rootJS)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.13.9, rootJVM)
+      - name: Download target directories (2.13.10, rootJVM)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.9-rootJVM
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.10-rootJVM
 
-      - name: Inflate target directories (2.13.9, rootJVM)
+      - name: Inflate target directories (2.13.10, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.13.9, rootNative)
+      - name: Download target directories (2.13.10, rootNative)
         uses: actions/download-artifact@v2
         with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.9-rootNative
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.10-rootNative
 
-      - name: Inflate target directories (2.13.9, rootNative)
+      - name: Inflate target directories (2.13.10, rootNative)
         run: |
           tar xf targets.tar
           rm targets.tar
@@ -350,7 +350,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.9]
+        scala: [2.13.10]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: nativeLink
         if: matrix.project == 'rootNative'
-        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' Test/nativeLink
+        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' Test/nativeLink
 
       - name: Test
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         os: [ubuntu-latest]
         scala: [2.12.17, 2.13.10, 3.2.1]
         java: [temurin@8, temurin@11, temurin@17]
-        project: [rootJS, rootJVM]
+        project: [rootJS, rootJVM, rootNative]
         exclude:
           - scala: 2.12.17
             java: temurin@11
@@ -44,6 +44,10 @@ jobs:
           - project: rootJS
             java: temurin@11
           - project: rootJS
+            java: temurin@17
+          - project: rootNative
+            java: temurin@11
+          - project: rootNative
             java: temurin@17
     runs-on: ${{ matrix.os }}
     steps:
@@ -123,6 +127,10 @@ jobs:
         if: matrix.project == 'rootJS'
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' Test/scalaJSLinkerResult
 
+      - name: nativeLink
+        if: matrix.project == 'rootNative'
+        run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' Test/nativeLink
+
       - name: Test
         run: sbt 'project ${{ matrix.project }}' '++${{ matrix.scala }}' test
 
@@ -144,11 +152,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p target .js/target site/target .jvm/target .native/target scala-xml/.js/target scala-xml/.jvm/target project/target
+        run: mkdir -p target .js/target site/target xml/.jvm/target xml-scala/.js/target xml/.js/target xml-scala/.native/target xml-scala/.jvm/target .jvm/target .native/target xml/.native/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar target .js/target site/target .jvm/target .native/target scala-xml/.js/target scala-xml/.jvm/target project/target
+        run: tar cf targets.tar target .js/target site/target xml/.jvm/target xml-scala/.js/target xml/.js/target xml-scala/.native/target xml-scala/.jvm/target .jvm/target .native/target xml/.native/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
@@ -253,6 +261,16 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
+      - name: Download target directories (2.12.17, rootNative)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.17-rootNative
+
+      - name: Inflate target directories (2.12.17, rootNative)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
       - name: Download target directories (2.13.10, rootJS)
         uses: actions/download-artifact@v2
         with:
@@ -273,6 +291,16 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
+      - name: Download target directories (2.13.10, rootNative)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.10-rootNative
+
+      - name: Inflate target directories (2.13.10, rootNative)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
       - name: Download target directories (3.2.1, rootJS)
         uses: actions/download-artifact@v2
         with:
@@ -289,6 +317,16 @@ jobs:
           name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.1-rootJVM
 
       - name: Inflate target directories (3.2.1, rootJVM)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.2.1, rootNative)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3.2.1-rootNative
+
+      - name: Inflate target directories (3.2.1, rootNative)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,6 @@
+-Dfile.encoding=UTF8
+-Xms1G
+-Xmx6G
+-XX:ReservedCodeCacheSize=250M
+-XX:+TieredCompilation
+-XX:+UseG1GC

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ ThisBuild / developers := List(
   tlGitHubDev("rossabaker", "Ross A. Baker")
 )
 
-val Scala213 = "2.13.8"
-ThisBuild / crossScalaVersions := Seq("2.12.16", Scala213, "3.1.3")
+val Scala213 = "2.13.9"
+ThisBuild / crossScalaVersions := Seq("2.12.17", Scala213, "3.2.0")
 ThisBuild / scalaVersion := Scala213
 
 // ensure missing timezones don't break tests on JS
@@ -15,13 +15,13 @@ ThisBuild / jsEnv := {
 
 lazy val root = tlCrossRootProject.aggregate(xml, xmlScala)
 
-val http4sVersion = "0.23.14"
+val http4sVersion = "0.23.16"
 val scalaXmlVersion = "2.1.0"
-val fs2DataVersion = "1.5.0+19-3dd4d2cc-SNAPSHOT"
-val munitVersion = "0.7.29"
-val munitCatsEffectVersion = "1.0.7"
+val fs2DataVersion = "1.5.1"
+val munitVersion = "1.0.0-M6"
+val munitCatsEffectVersion = "2.0.0-M3"
 
-lazy val xml = crossProject(JVMPlatform, JSPlatform)
+lazy val xml = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .in(file("xml"))
   .settings(
@@ -33,12 +33,12 @@ lazy val xml = crossProject(JVMPlatform, JSPlatform)
       "org.http4s" %%% "http4s-core" % http4sVersion,
       "org.gnieh" %%% "fs2-data-xml" % fs2DataVersion,
       "org.scalameta" %%% "munit-scalacheck" % munitVersion % Test,
-      "org.typelevel" %%% "munit-cats-effect-3" % munitCatsEffectVersion % Test,
+      "org.typelevel" %%% "munit-cats-effect" % munitCatsEffectVersion % Test,
       "org.http4s" %%% "http4s-laws" % http4sVersion % Test,
     ),
   )
 
-lazy val xmlScala = crossProject(JVMPlatform, JSPlatform)
+lazy val xmlScala = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .in(file("xml-scala"))
   .dependsOn(xml)
@@ -51,7 +51,7 @@ lazy val xmlScala = crossProject(JVMPlatform, JSPlatform)
       "org.scala-lang.modules" %%% "scala-xml" % scalaXmlVersion,
       "org.gnieh" %%% "fs2-data-xml-scala" % fs2DataVersion,
       "org.scalameta" %%% "munit-scalacheck" % munitVersion % Test,
-      "org.typelevel" %%% "munit-cats-effect-3" % munitCatsEffectVersion % Test,
+      "org.typelevel" %%% "munit-cats-effect" % munitCatsEffectVersion % Test,
       // "org.typelevel" %%% "scalacheck-xml" % "0.1.0" % Test,
       "org.http4s" %%% "http4s-laws" % http4sVersion % Test,
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val xml = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "org.scalameta" %%% "munit-scalacheck" % munitVersion % Test,
       "org.typelevel" %%% "munit-cats-effect" % munitCatsEffectVersion % Test,
       "org.http4s" %%% "http4s-laws" % http4sVersion % Test,
-    )
+    ),
   )
 
 lazy val xmlScala = crossProject(JVMPlatform, JSPlatform, NativePlatform)
@@ -58,7 +58,7 @@ lazy val xmlScala = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "org.typelevel" %%% "munit-cats-effect" % munitCatsEffectVersion % Test,
       // "org.typelevel" %%% "scalacheck-xml" % "0.1.0" % Test,
       "org.http4s" %%% "http4s-laws" % http4sVersion % Test,
-    )
+    ),
   )
 
 lazy val docs = project

--- a/build.sbt
+++ b/build.sbt
@@ -13,34 +13,53 @@ ThisBuild / jsEnv := {
   new NodeJSEnv(NodeJSEnv.Config().withEnv(Map("TZ" -> "UTC")))
 }
 
-lazy val root = tlCrossRootProject.aggregate(scalaXml)
+lazy val root = tlCrossRootProject.aggregate(xml, xmlScala)
 
 val http4sVersion = "0.23.14"
 val scalaXmlVersion = "2.1.0"
-val fs2DataVersion = "1.5.0"
+val fs2DataVersion = "1.5.0+19-3dd4d2cc-SNAPSHOT"
 val munitVersion = "0.7.29"
 val munitCatsEffectVersion = "1.0.7"
 
-lazy val scalaXml = crossProject(JVMPlatform, JSPlatform)
+lazy val xml = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
-  .in(file("scala-xml"))
+  .in(file("xml"))
   .settings(
-    name := "http4s-scala-xml",
-    description := "Provides scala-xml codecs for http4s",
-    startYear := Some(2014),
+    name := "http4s-fs2-data-xml",
+    description := "Provides xml codecs for http4s via fs2-data",
+    startYear := Some(2022),
     libraryDependencies ++= Seq(
+      "co.fs2" %%% "fs2-core" % "3.3.0-47-85f745e-20221004T141927Z-SNAPSHOT",
       "org.http4s" %%% "http4s-core" % http4sVersion,
-      "org.scala-lang.modules" %%% "scala-xml" % scalaXmlVersion,
-      "org.gnieh" %%% "fs2-data-xml-scala" % fs2DataVersion,
+      "org.gnieh" %%% "fs2-data-xml" % fs2DataVersion,
       "org.scalameta" %%% "munit-scalacheck" % munitVersion % Test,
       "org.typelevel" %%% "munit-cats-effect-3" % munitCatsEffectVersion % Test,
       "org.http4s" %%% "http4s-laws" % http4sVersion % Test,
     ),
   )
 
+lazy val xmlScala = crossProject(JVMPlatform, JSPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("xml-scala"))
+  .dependsOn(xml)
+  .settings(
+    name := "http4s-fs2-data-xml-scala",
+    description := "Provides scala-xml codecs for http4s via fs2-data",
+    startYear := Some(2022),
+    libraryDependencies ++= Seq(
+      "org.http4s" %%% "http4s-core" % http4sVersion,
+      "org.scala-lang.modules" %%% "scala-xml" % scalaXmlVersion,
+      "org.gnieh" %%% "fs2-data-xml-scala" % fs2DataVersion,
+      "org.scalameta" %%% "munit-scalacheck" % munitVersion % Test,
+      "org.typelevel" %%% "munit-cats-effect-3" % munitCatsEffectVersion % Test,
+      // "org.typelevel" %%% "scalacheck-xml" % "0.1.0" % Test,
+      "org.http4s" %%% "http4s-laws" % http4sVersion % Test,
+    ),
+  )
+
 lazy val docs = project
   .in(file("site"))
-  .dependsOn(scalaXml.jvm)
+  .dependsOn(xml.jvm, xmlScala.jvm)
   .settings(
     libraryDependencies ++= Seq(
       "org.http4s" %%% "http4s-dsl" % http4sVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -7,9 +7,6 @@ val Scala213 = "2.13.10"
 ThisBuild / crossScalaVersions := Seq("2.12.17", Scala213, "3.2.1")
 ThisBuild / scalaVersion := Scala213
 
-// Remove once we don't need fs2 snapshot anymore
-ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
-
 // ensure missing timezones don't break tests on JS
 ThisBuild / jsEnv := {
   import org.scalajs.jsenv.nodejs.NodeJSEnv
@@ -20,7 +17,7 @@ lazy val root = tlCrossRootProject.aggregate(xml, xmlScala)
 
 val http4sVersion = "0.23.16"
 val scalaXmlVersion = "2.1.0"
-val fs2Version = "3.3.0-99-0a0d363-SNAPSHOT"
+val fs2Version = "3.4.0"
 val fs2DataVersion = "1.6.0"
 val munitVersion = "1.0.0-M7"
 val munitCatsEffectVersion = "2.0.0-M3"

--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,11 @@ ThisBuild / developers := List(
   tlGitHubDev("rossabaker", "Ross A. Baker")
 )
 
-val Scala213 = "2.13.9"
+val Scala213 = "2.13.10"
 ThisBuild / crossScalaVersions := Seq("2.12.17", Scala213, "3.2.0")
 ThisBuild / scalaVersion := Scala213
+
+ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
 // ensure missing timezones don't break tests on JS
 ThisBuild / jsEnv := {
@@ -17,6 +19,7 @@ lazy val root = tlCrossRootProject.aggregate(xml, xmlScala)
 
 val http4sVersion = "0.23.16"
 val scalaXmlVersion = "2.1.0"
+val fs2Version = "3.3.0-99-0a0d363-SNAPSHOT"
 val fs2DataVersion = "1.5.1"
 val munitVersion = "1.0.0-M6"
 val munitCatsEffectVersion = "2.0.0-M3"
@@ -29,7 +32,7 @@ lazy val xml = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     description := "Provides xml codecs for http4s via fs2-data",
     startYear := Some(2022),
     libraryDependencies ++= Seq(
-      "co.fs2" %%% "fs2-core" % "3.3.0-47-85f745e-20221004T141927Z-SNAPSHOT",
+      "co.fs2" %%% "fs2-core" % fs2Version,
       "org.http4s" %%% "http4s-core" % http4sVersion,
       "org.gnieh" %%% "fs2-data-xml" % fs2DataVersion,
       "org.scalameta" %%% "munit-scalacheck" % munitVersion % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,7 @@ lazy val xml = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "org.typelevel" %%% "munit-cats-effect" % munitCatsEffectVersion % Test,
       "org.http4s" %%% "http4s-laws" % http4sVersion % Test,
     ),
+    unusedCompileDependenciesTest := {}, // Doesn't work for Scala Native
   )
 
 lazy val xmlScala = crossProject(JVMPlatform, JSPlatform, NativePlatform)
@@ -58,6 +59,7 @@ lazy val xmlScala = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       // "org.typelevel" %%% "scalacheck-xml" % "0.1.0" % Test,
       "org.http4s" %%% "http4s-laws" % http4sVersion % Test,
     ),
+    unusedCompileDependenciesTest := {}, // Doesn't work for Scala Native
   )
 
 lazy val docs = project

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,20 @@
-# http4s-scala-xml
+# http4s-fs2-data-xml
+
+Provides basic support for parsing and encoding `fs2.data.xml.XmlEvent` streams that can be handled in a streaming fashion
+using the pipes and builders `fs2-data` provides.
 
 ```scala
-libraryDependencies += "org.http4s" %% "http4s-scala-xml" % "@VERSION@"
+libraryDependencies += "org.http4s" %% "http4s-fs2-data-xml" % "@VERSION@"
+```
+
+# http4s-fs2-data-xml-scala
+
+Provides additional integration with `scala-xml` to work directly with its `Document` ans `Elem` types. To some extent, 
+this module is a drop-in replacement for the `http4s-scala-xml` module, but it provides additional streaming capabilities
+`scala-xml` doesn't.
+
+```scala
+libraryDependencies += "org.http4s" %% "http4s-fs2-data-xml-scala" % "@VERSION@"
 ```
 
 ## Example
@@ -38,7 +51,7 @@ class JsonXmlHttpEndpoint[F[_]](implicit F: Async[F]) extends Http4sDsl[F] {
   }
 
   private def personXmlDecoder: EntityDecoder[F, Person] =
-    org.http4s.scalaxml.xmlDocument[F].map(Person.fromXml)
+    org.http4s.fs2data.xml.scalaxml.xmlDocumentDecoder.map(Person.fromXml)
 
   implicit private def jsonXmlDecoder: EntityDecoder[F, Person] =
     jsonOf[F, Person].orElse(personXmlDecoder)

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,0 +1,1 @@
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,1 +1,0 @@
-resolvers ++= Resolver.sonatypeOssRepos("snapshots")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.http4s" % "sbt-http4s-org" % "0.14.6")
+addSbtPlugin("org.http4s" % "sbt-http4s-org" % "0.14.7")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.11.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.7")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.2.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,6 @@
-addSbtPlugin("org.http4s" % "sbt-http4s-org" % "0.14.5")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.0")
+addSbtPlugin("org.http4s" % "sbt-http4s-org" % "0.14.6")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.11.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.7")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.2.0")
 // Fix links to API docs of scala-xml
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.http4s" % "sbt-http4s-org" % "0.14.7")
+addSbtPlugin("org.http4s" % "sbt-http4s-org" % "0.14.7-11-405a56a-SNAPSHOT")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.11.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.7")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.2.0")

--- a/xml-scala/src/main/scala/org/http4s/fs2data/xml/scalaxml/ElemInstances.scala
+++ b/xml-scala/src/main/scala/org/http4s/fs2data/xml/scalaxml/ElemInstances.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s
+package fs2data
+package xml
+package scalaxml
+
+import cats.effect.Concurrent
+import cats.syntax.all._
+import fs2.Stream
+import fs2.data.xml.dom
+import fs2.data.xml.scalaXml._
+import fs2.data.xml.XmlException
+import org.http4s.Charset.`UTF-8`
+
+import scala.xml.Document
+import scala.xml.Elem
+
+trait ElemInstances extends XmlEventInstances {
+
+  implicit def xmlElemEncoder[F[_]](implicit
+      charset: Charset = `UTF-8`
+  ): EntityEncoder[F, Elem] =
+    xmlDocumentEncoder[F].contramap[Elem] { e =>
+      ScalaXmlBuilder.makeDocument(Some("1.0"), Some(charset.renderString), None, None, Nil, e, Nil)
+    }
+
+  implicit def xmlDocumentEncoder[F[_]](implicit
+      charset: Charset = `UTF-8`
+  ): EntityEncoder[F, Document] =
+    xmlDocumentStreamEncoder[F].contramap[Document](Stream.emit)
+
+  implicit def xmlDocumentStreamEncoder[F[_]](implicit
+      charset: Charset = `UTF-8`
+  ): EntityEncoder[F, Stream[F, Document]] =
+    xmlEventsEncoder[F].contramap(dom.eventify[F, Document])
+
+  implicit def xmlDocumentDecoder[F[_]: Concurrent]: EntityDecoder[F, Document] =
+    xmlDocumentDecoder(true)
+
+  def xmlDocumentDecoder[F[_]: Concurrent](includeComments: Boolean): EntityDecoder[F, Document] =
+    xmlDocumentStreamDecoder(includeComments).flatMapR[Document] { docs =>
+      DecodeResult(
+        docs.head.compile.last
+          .flatMap(_.liftTo[F](MalformedMessageBodyFailure("No XML document found", None)))
+          .attemptNarrow[DecodeFailure]
+      )
+    }
+
+  /** Handles a message body as a stream of XML documents.
+    *
+    * @return a stream of XML [[scala.xml.Document]]
+    */
+  implicit def xmlDocumentStreamDecoder[F[_]: Concurrent]: EntityDecoder[F, Stream[F, Document]] =
+    xmlDocumentStreamDecoder(includeComments = true)
+
+  /** Handles a message body as XML.
+    *
+    * @return an XML [[scala.xml.Document]]
+    */
+  def xmlDocumentStreamDecoder[F[_]](
+      includeComments: Boolean
+  )(implicit F: Concurrent[F]): EntityDecoder[F, Stream[F, Document]] =
+    xmlEventsDecoder(includeComments).map { events =>
+      events
+        .through(fs2.data.xml.dom.documents)
+        .adaptError { case ex: XmlException =>
+          MalformedMessageBodyFailure("Invalid XML", Some(ex))
+        }
+    }
+}

--- a/xml-scala/src/main/scala/org/http4s/fs2data/xml/scalaxml/ElemInstances.scala
+++ b/xml-scala/src/main/scala/org/http4s/fs2data/xml/scalaxml/ElemInstances.scala
@@ -22,9 +22,9 @@ package scalaxml
 import cats.effect.Concurrent
 import cats.syntax.all._
 import fs2.Stream
+import fs2.data.xml.XmlException
 import fs2.data.xml.dom
 import fs2.data.xml.scalaXml._
-import fs2.data.xml.XmlException
 import org.http4s.Charset.`UTF-8`
 
 import scala.xml.Document

--- a/xml-scala/src/main/scala/org/http4s/fs2data/xml/scalaxml/ElemInstances.scala
+++ b/xml-scala/src/main/scala/org/http4s/fs2data/xml/scalaxml/ElemInstances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 http4s.org
+ * Copyright 2022 http4s.org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xml-scala/src/main/scala/org/http4s/fs2data/xml/scalaxml/package.scala
+++ b/xml-scala/src/main/scala/org/http4s/fs2data/xml/scalaxml/package.scala
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-package org.http4s
+package org.http4s.fs2data.xml
 
 package object scalaxml extends ElemInstances

--- a/xml-scala/src/main/scala/org/http4s/fs2data/xml/scalaxml/package.scala
+++ b/xml-scala/src/main/scala/org/http4s/fs2data/xml/scalaxml/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 http4s.org
+ * Copyright 2022 http4s.org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xml-scala/src/test/scala/org/http4s/fs2data/xml/scalaxml/ScalaXmlSuite.scala
+++ b/xml-scala/src/test/scala/org/http4s/fs2data/xml/scalaxml/ScalaXmlSuite.scala
@@ -286,8 +286,8 @@ class ScalaXmlSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
       "application/xml; charset=iso-2022-kr",
       "문재인",
     ).unlessA(
-      sys.props("java.vm.name") === "Scala.js"
-    ) // exclude test on Scala.js as it doesn't support this charset
+      sys.props("java.vm.name") === "Scala.js" || sys.props("java.vm.name") === "Scala Native"
+    ) // exclude test on Scala.js / Scala Native as they don't support this charset
   }
 
   test("parse conflicting charset and internal encoding") {

--- a/xml-scala/src/test/scala/org/http4s/fs2data/xml/scalaxml/ScalaXmlSuite.scala
+++ b/xml-scala/src/test/scala/org/http4s/fs2data/xml/scalaxml/ScalaXmlSuite.scala
@@ -26,9 +26,9 @@ import fs2.text.utf8
 import munit.CatsEffectSuite
 import munit.ScalaCheckEffectSuite
 import org.http4s.Status.Ok
+import org.http4s.fs2data.xml.scalaxml.generators._
 import org.http4s.headers.`Content-Type`
 import org.http4s.laws.discipline.arbitrary._
-import org.http4s.fs2data.xml.scalaxml.generators._
 import org.scalacheck.Prop._
 import org.scalacheck.effect.PropF._
 import org.typelevel.ci._

--- a/xml-scala/src/test/scala/org/http4s/fs2data/xml/scalaxml/ScalaXmlSuite.scala
+++ b/xml-scala/src/test/scala/org/http4s/fs2data/xml/scalaxml/ScalaXmlSuite.scala
@@ -15,7 +15,7 @@
  */
 
 package org.http4s
-package scalaxml
+package fs2data.xml.scalaxml
 
 import cats.effect._
 import cats.syntax.all._
@@ -28,7 +28,7 @@ import munit.ScalaCheckEffectSuite
 import org.http4s.Status.Ok
 import org.http4s.headers.`Content-Type`
 import org.http4s.laws.discipline.arbitrary._
-import org.http4s.scalaxml.generators._
+import org.http4s.fs2data.xml.scalaxml.generators._
 import org.scalacheck.Prop._
 import org.scalacheck.effect.PropF._
 import org.typelevel.ci._
@@ -94,56 +94,55 @@ class ScalaXmlSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
     implicit val cs: Charset = Charset.`UTF-8`
     assertIO(
       writeToString(html),
-      """<?xml version='1.0' encoding='UTF-8'?>
-        |<html><body>Hello</body></html>""".stripMargin,
+      """<?xml version="1.0" encoding="UTF-8"?><html><body>Hello</body></html>""",
     )
   }
 
   test("encode to UTF-8") {
     val hello = <hello name="Günther"/>
     assertIO(
-      xmlEncoder[IO](Charset.`UTF-8`)
+      xmlElemEncoder[IO](Charset.`UTF-8`)
         .toEntity(hello)
         .body
         .through(fs2.text.utf8.decode)
         .compile
         .string,
-      """<?xml version='1.0' encoding='UTF-8'?>
-        |<hello name="Günther"/>""".stripMargin,
+      """<?xml version="1.0" encoding="UTF-8"?><hello name="Günther"/>""",
     )
   }
 
   test("encode to UTF-16") {
     val hello = <hello name="Günther"/>
     assertIO(
-      xmlEncoder[IO](Charset.`UTF-16`)
+      xmlElemEncoder[IO](Charset.`UTF-16`)
         .toEntity(hello)
         .body
         .through(decodeWithCharset(StandardCharsets.UTF_16))
         .compile
         .string,
-      """<?xml version='1.0' encoding='UTF-16'?>
-        |<hello name="Günther"/>""".stripMargin,
+      """<?xml version="1.0" encoding="UTF-16"?><hello name="Günther"/>""",
     )
   }
 
   test("encode to ISO-8859-1") {
     val hello = <hello name="Günther"/>
     assertIO(
-      xmlEncoder[IO](Charset.`ISO-8859-1`)
+      xmlElemEncoder[IO](Charset.`ISO-8859-1`)
         .toEntity(hello)
         .body
         .through(decodeWithCharset(StandardCharsets.ISO_8859_1))
         .compile
         .string,
-      """<?xml version='1.0' encoding='ISO-8859-1'?>
-        |<hello name="Günther"/>""".stripMargin,
+      """<?xml version="1.0" encoding="ISO-8859-1"?><hello name="Günther"/>""",
     )
   }
 
   property("encoder sets charset of Content-Type") {
     forAll { (cs: Charset) =>
-      assertEquals(xmlEncoder[IO](cs).headers.get[`Content-Type`].flatMap(_.charset), Some(cs))
+      assertEquals(
+        xmlElemEncoder[IO](cs).headers.get[`Content-Type`].flatMap(_.charset),
+        Some(cs),
+      )
     }
   }
 

--- a/xml-scala/src/test/scala/org/http4s/fs2data/xml/scalaxml/ScalaXmlSuite.scala
+++ b/xml-scala/src/test/scala/org/http4s/fs2data/xml/scalaxml/ScalaXmlSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 http4s.org
+ * Copyright 2022 http4s.org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xml-scala/src/test/scala/org/http4s/fs2data/xml/scalaxml/generators.scala
+++ b/xml-scala/src/test/scala/org/http4s/fs2data/xml/scalaxml/generators.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 http4s.org
+ * Copyright 2022 http4s.org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xml-scala/src/test/scala/org/http4s/fs2data/xml/scalaxml/generators.scala
+++ b/xml-scala/src/test/scala/org/http4s/fs2data/xml/scalaxml/generators.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.http4s.scalaxml
+package org.http4s.fs2data.xml.scalaxml
 
 import org.scalacheck.Gen
 

--- a/xml/src/main/scala/org/http4s/fs2data/xml/XmlEventInstances.scala
+++ b/xml/src/main/scala/org/http4s/fs2data/xml/XmlEventInstances.scala
@@ -24,11 +24,12 @@ import cats.syntax.all._
 import fs2.Chunk
 import fs2.Pull
 import fs2.Stream
-import fs2.data.xml.render
 import fs2.data.xml.XmlEvent
+import fs2.data.xml.render
 import fs2.text.decodeWithCharset
 import org.http4s.Charset.`UTF-8`
-import org.http4s.headers.{`Content-Type`, `Transfer-Encoding`}
+import org.http4s.headers.`Content-Type`
+import org.http4s.headers.`Transfer-Encoding`
 
 import scala.util.matching.Regex
 

--- a/xml/src/main/scala/org/http4s/fs2data/xml/XmlEventInstances.scala
+++ b/xml/src/main/scala/org/http4s/fs2data/xml/XmlEventInstances.scala
@@ -15,42 +15,45 @@
  */
 
 package org.http4s
-package scalaxml
+package fs2data
+package xml
 
+import cats.data.NonEmptyList
 import cats.effect.Concurrent
 import cats.syntax.all._
 import fs2.Chunk
 import fs2.Pull
 import fs2.Stream
+import fs2.data.xml.render
 import fs2.data.xml.XmlEvent
-import fs2.data.xml.XmlException
-import fs2.data.xml.scalaXml._
 import fs2.text.decodeWithCharset
 import org.http4s.Charset.`UTF-8`
-import org.http4s.headers.`Content-Type`
+import org.http4s.headers.{`Content-Type`, `Transfer-Encoding`}
 
-import java.io.StringWriter
 import scala.util.matching.Regex
-import scala.xml.Document
-import scala.xml.Elem
-import scala.xml.XML
 
-trait ElemInstances {
+trait XmlEventInstances {
 
-  implicit def xmlEncoder[F[_]](implicit charset: Charset = `UTF-8`): EntityEncoder[F, Elem] =
-    EntityEncoder
-      .stringEncoder[F]
-      .contramap[Elem] { node =>
-        val sw = new StringWriter
-        XML.write(sw, node, charset.nioCharset.name, true, null)
-        sw.toString
-      }
-      .withContentType(`Content-Type`(MediaType.application.xml).withCharset(charset))
+  implicit def xmlEventsEncoder[F[_]](implicit
+      charset: Charset = `UTF-8`
+  ): EntityEncoder[F, Stream[F, XmlEvent]] =
+    EntityEncoder.encodeBy(
+      Headers(
+        `Content-Type`(MediaType.application.xml).withCharset(charset),
+        `Transfer-Encoding`(TransferCoding.chunked.pure[NonEmptyList]),
+      )
+    )(events =>
+      Entity(
+        events
+          .through(render())
+          .through(fs2.text.encode[F](charset.nioCharset))
+      )
+    )
 
-  implicit def xmlEvents[F[_]: Concurrent]: EntityDecoder[F, Stream[F, XmlEvent]] =
-    xmlEvents(true)
+  implicit def xmlEventsDecoder[F[_]: Concurrent]: EntityDecoder[F, Stream[F, XmlEvent]] =
+    xmlEventsDecoder(true)
 
-  def xmlEvents[F[_]](
+  def xmlEventsDecoder[F[_]](
       includeComments: Boolean
   )(implicit F: Concurrent[F]): EntityDecoder[F, Stream[F, XmlEvent]] =
     EntityDecoder.decodeBy(MediaType.text.xml, MediaType.text.html, MediaType.application.xml) {
@@ -93,43 +96,15 @@ trait ElemInstances {
         )
     }
 
-  /** Handles a message body as XML.
-    *
-    * @return an XML [[scala.xml.Document]]
-    */
-  implicit def xmlDocument[F[_]: Concurrent]: EntityDecoder[F, Document] =
-    xmlDocument(true)
-
-  /** Handles a message body as XML.
-    *
-    * @return an XML [[scala.xml.Document]]
-    */
-  def xmlDocument[F[_]](
-      includeComments: Boolean
-  )(implicit F: Concurrent[F]): EntityDecoder[F, Document] =
-    xmlEvents(includeComments).flatMapR { events =>
-      DecodeResult {
-        events
-          .through(fs2.data.xml.dom.documents)
-          .head
-          .compile
-          .lastOrError
-          .map(Either.right[MalformedMessageBodyFailure, Document](_))
-          .recover { case ex: XmlException =>
-            Left(MalformedMessageBodyFailure("Invalid XML", Some(ex)))
-          }
-          .widen
-      }
-    }
-
   // Extract the encoding from the XML prolog if present. Attribute order is fixed for prologs by the spec
   // and additional whitespace is not allowed, so this strict regex should work reliably.
-  private val prologWithEncoding: Regex = """<\?xml version=".+" encoding="([^"]+)".*""".r
+  private val prologWithEncoding: Regex =
+    """<\?xml version=['"].+['"] encoding=['"]([^"']+)['"].*""".r
 
   private lazy val `BOM-BE` = Chunk(0xfe.toByte, 0xff.toByte)
   private lazy val `BOM-LE` = Chunk(0xff.toByte, 0xfe.toByte)
 
-  private def guessCharset(in: String): ParseResult[Charset] = in match {
+  private[xml] def guessCharset(in: String): ParseResult[Charset] = in match {
     case prologWithEncoding(encoding) => Charset.fromString(encoding)
     case _ => Right(Charset.`UTF-8`)
   }

--- a/xml/src/main/scala/org/http4s/fs2data/xml/XmlEventInstances.scala
+++ b/xml/src/main/scala/org/http4s/fs2data/xml/XmlEventInstances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 http4s.org
+ * Copyright 2022 http4s.org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xml/src/main/scala/org/http4s/fs2data/xml/package.scala
+++ b/xml/src/main/scala/org/http4s/fs2data/xml/package.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2014 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.fs2data
+
+package object xml extends XmlEventInstances

--- a/xml/src/main/scala/org/http4s/fs2data/xml/package.scala
+++ b/xml/src/main/scala/org/http4s/fs2data/xml/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 http4s.org
+ * Copyright 2022 http4s.org
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xml/src/test/scala/org/http4s/fs2data/xml/XmlEventSuite.scala
+++ b/xml/src/test/scala/org/http4s/fs2data/xml/XmlEventSuite.scala
@@ -20,8 +20,11 @@ import cats.effect.IO
 import cats.syntax.all._
 import fs2.Stream
 import fs2.data.xml._
-import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
-import org.http4s.{Charset, EntityDecoder, Request}
+import munit.CatsEffectSuite
+import munit.ScalaCheckEffectSuite
+import org.http4s.Charset
+import org.http4s.EntityDecoder
+import org.http4s.Request
 
 class XmlEventSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
 

--- a/xml/src/test/scala/org/http4s/fs2data/xml/XmlEventSuite.scala
+++ b/xml/src/test/scala/org/http4s/fs2data/xml/XmlEventSuite.scala
@@ -1,0 +1,80 @@
+package org.http4s.fs2data.xml
+
+import cats.effect.IO
+import cats.syntax.all._
+import fs2.Stream
+import fs2.data.xml._
+import munit.{CatsEffectSuite, ScalaCheckEffectSuite}
+import org.http4s.{Charset, EntityDecoder, Request}
+
+class XmlEventSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
+
+  test("round-trip XML") {
+    val in = xml"""<?xml version="1.0"?><root a="b"><something/></root>"""
+    Stream
+      .force(Request[IO]().withEntity(in.lift[IO]).as[Stream[IO, XmlEvent]])
+      .compile
+      .toList
+      .map(_.asRight[Throwable])
+      .assertEquals(in.toList)
+  }
+
+  test("round-trip XML string") {
+    val in = """<?xml version="1.0"?><root a="b"><something/></root>"""
+    Request[IO]()
+      .withEntity(in)
+      .as[Stream[IO, XmlEvent]]
+      .map(Request[IO]().withEntity(_))
+      .flatMap(EntityDecoder.text[IO].decode(_, false).value)
+      .assertEquals(Right(in))
+  }
+
+  test("preserves comments by default") {
+    val in = rawxml"""<?xml version="1.0"?><root><!-- here's a comment --></root>"""
+    Stream
+      .force(Request[IO]().withEntity(in.lift[IO]).as[Stream[IO, XmlEvent]])
+      .compile
+      .toList
+      .map(_.asRight[Throwable])
+      .assertEquals(in.toList)
+  }
+
+  test("can disable comments") {
+    val in = rawxml"""<?xml version="1.0"?><root><!-- here's a comment --></root>"""
+    Stream
+      .force(
+        Request[IO]()
+          .withEntity(in.lift[IO])
+          .as[Stream[IO, XmlEvent]](implicitly, xmlEventsDecoder(false))
+      )
+      .compile
+      .toList
+      .map(_.asRight[Throwable])
+      .assertEquals(in.filterNot(_.isInstanceOf[XmlEvent.Comment]).toList)
+  }
+
+  test("supports charsets") {
+    implicit val charset: Charset = Charset.`UTF-16`
+    val in = xml"""<?xml version="1.0" encoding="utf-16"?><root a="b"><something/></root>"""
+    Stream
+      .force(Request[IO]().withEntity(in.lift[IO]).as[Stream[IO, XmlEvent]])
+      .compile
+      .toList
+      .map(_.asRight[Throwable])
+      .assertEquals(in.toList)
+  }
+
+  test("guesses charsets correctly") {
+    def check(xml: String, cs: Charset) = assertEquals(guessCharset(xml), Right(cs))
+
+    check("""<?xml version="1.0" encoding="utf-8"?>""", Charset.`UTF-8`)
+    check("""<?xml version="1.0" encoding="utf-16" ?>""", Charset.`UTF-16`)
+    check("""<?xml version="1.0" encoding="ascii"?>""", Charset.`US-ASCII`)
+    check("""<?xml version='1.0' encoding='ascii'?>""", Charset.`US-ASCII`)
+    // fallback
+    check("""<?xml version="1.0"?>""", Charset.`UTF-8`)
+    check("""garbage""", Charset.`UTF-8`)
+    check("", Charset.`UTF-8`)
+  }
+
+}

--- a/xml/src/test/scala/org/http4s/fs2data/xml/XmlEventSuite.scala
+++ b/xml/src/test/scala/org/http4s/fs2data/xml/XmlEventSuite.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.http4s.fs2data.xml
 
 import cats.effect.IO


### PR DESCRIPTION
Needs a fs2 snapshot still due typelevel/fs2#3006, but other than that, features fully working `xml` and `xml-scala` modules with native support and up-to-date dependencies.