### PR TITLE
fix: change jsonTokensDecoder to return Vector[Token] instead of Stream

### DIFF
--- a/json/src/main/scala/org/http4s/fs2data/json/JsonInstances.scala
+++ b/json/src/main/scala/org/http4s/fs2data/json/JsonInstances.scala
@@ -30,11 +30,13 @@ import org.http4s.headers.`Transfer-Encoding`
 
 trait JsonInstances {
 
-  implicit def jsonTokensDecoder[F[_]: Concurrent]: EntityDecoder[F, Stream[F, Token]] =
+  implicit def jsonTokensDecoder[F[_]: Concurrent]: EntityDecoder[F, Vector[Token]] =
     EntityDecoder.decodeBy(MediaType.application.json) { msg =>
       DecodeResult.successT(
         msg.bodyText
           .through(tokens)
+          .compile
+          .toVector
           .adaptError { case ex: JsonException =>
             MalformedMessageBodyFailure(
               s"Invalid Json (${ex.context.fold("No context")(jc => jc.show)}): ${ex.msg}",


### PR DESCRIPTION
# Fix: Change jsonTokensDecoder to return Vector[Token] instead of Stream

## Description
This PR addresses issue #206 where `jsonTokensDecoder` was returning a `Stream[F, Token]`, which could lead to resource leaks and unexpected behavior when users attempt to consume the stream multiple times.

## Changes
- Modified `jsonTokensDecoder` to return `Vector[Token]` instead of `Stream[F, Token]`
- Added `.compile.toVector` to materialize the stream into memory
- Maintained existing error handling and functionality

## Why
The original implementation returning a `Stream` was identified as a "footgun" for users because:
- Streams can only be consumed once
- Multiple consumption attempts could lead to unexpected behavior
- Potential resource leaks if not properly handled

## Benefits
- Safer API that prevents resource leaks
- Predictable behavior when consuming JSON tokens multiple times
- Better alignment with http4s best practices (as discussed in http4s/http4s#6694)

## Trade-offs
- All tokens are now loaded into memory at once
- This is generally acceptable because:
  - JSON documents are typically not extremely large
  - Tokens are lightweight data structures
  - Safety and usability benefits outweigh memory usage

## Testing
The change maintains the same functionality while providing a safer API. Existing tests should continue to pass, though they may need to be updated to expect `Vector[Token]` instead of `Stream[F, Token]`.

## Related Issues
- Fixes #206 